### PR TITLE
Fixed edit date permissions at dashboard

### DIFF
--- a/Tools/CMS.php
+++ b/Tools/CMS.php
@@ -115,7 +115,7 @@ class CMS {
             $value = '';
         }
 
-        // check if current user can edit datra field
+        // check if current user can edit data field
         // set default
         $letUserEdit = ClientUser::getInstance()->isAdmin();
         if ( !empty($settings['permission'])) {
@@ -125,11 +125,11 @@ class CMS {
             } elseif (array_key_exists("user_role",$settings['permission'])) {
                 // if set user's role
                 //TODO: for implement we need move USER::hasrole() to lightning
-                $letUserEdit = ( ClientUser::getInstance()->isAdmin() ) ? TRUE : FALSE ;
+                $letUserEdit = ClientUser::getInstance()->isAdmin();
             } elseif (array_key_exists("user_permission",$settings['permission'])) {
                 // if set user's permission
                 //TODO: for implement we need move USER::haspermission() to lightning
-                $letUserEdit = ( ClientUser::getInstance()->isAdmin() ) ? TRUE : FALSE ;
+                $letUserEdit = ClientUser::getInstance()->isAdmin();
             }
         }
 

--- a/Tools/CMS.php
+++ b/Tools/CMS.php
@@ -114,7 +114,26 @@ class CMS {
         } else {
             $value = '';
         }
-        if (ClientUser::getInstance()->isAdmin()) {
+
+        // check if current user can edit datra field
+        // set default
+        $letUserEdit = ClientUser::getInstance()->isAdmin();
+        if ( !empty($settings['permission'])) {
+            if (array_key_exists("user_id",$settings['permission'])) {
+                // if set user's id
+                $letUserEdit = ( ClientUser::getInstance()->user_id == $settings['permission']['user_id'] OR ClientUser::getInstance()->isAdmin() ) ? TRUE : FALSE ;
+            } elseif (array_key_exists("user_role",$settings['permission'])) {
+                // if set user's role
+                //TODO: for implement we need move USER::hasrole() to lightning
+                $letUserEdit = ( ClientUser::getInstance()->isAdmin() ) ? TRUE : FALSE ;
+            } elseif (array_key_exists("user_permission",$settings['permission'])) {
+                // if set user's permission
+                //TODO: for implement we need move USER::haspermission() to lightning
+                $letUserEdit = ( ClientUser::getInstance()->isAdmin() ) ? TRUE : FALSE ;
+            }
+        }
+
+        if ($letUserEdit) {
             JS::startup('lightning.cms.initDate()');
             JS::set('token', Session::getInstance()->getToken());
             return '<img src="/images/lightning/pencil.png" class="cms_edit_date icon-16" id="cms_edit_' . $settings['id'] . '">'


### PR DESCRIPTION
added ability to check permissions on edit field by set 'user_id', 'user_role' and 'user_permission', But checking roles and permissions we had implemented in Source/Model/User.php . So if we need these checks of permissions - wew should add hasRole()  and hasPermission() methods to  Lightning. Right now they are just aliases for check if user admin